### PR TITLE
add ex_doc dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,8 @@ defmodule Base58Encode.MixProject do
   defp deps do
     [ {:excoveralls, "~> 0.10", only: :test},
       {:basefiftyeight, "~> 0.1.0", only: :test},
-      {:stream_data, "~> 0.1", only: :test}
+      {:stream_data, "~> 0.1", only: :test},
+      {:ex_doc, "~> 0.19.3", only: :dev}
     ]
   end
 


### PR DESCRIPTION
ref: https://github.com/dwyl/base58encode/issues/7#…issuecomment-459301835

When publishing an Elixir package, the documentation will be generated automatically but for this the ex_doc dependency needs to be added to the project